### PR TITLE
Add the possibility to configure I2C pins

### DIFF
--- a/src/SFE_BMP180.cpp
+++ b/src/SFE_BMP180.cpp
@@ -32,11 +32,24 @@ SFE_BMP180::SFE_BMP180()
 char SFE_BMP180::begin()
 // Initialize library for subsequent pressure measurements
 {
-	double c3,c4,b1;
-	
 	// Start up the Arduino's "wire" (I2C) library:
-	
 	Wire.begin();
+	return initCalibration();
+}
+
+char SFE_BMP180::begin(int sda, int slc)
+// Initialize library for subsequent pressure measurements
+// sda, slc : i2c pin used
+{
+	// Start up the Arduino's "wire" (I2C) library:
+	Wire.begin(sda, slc);
+	return initCalibration();
+}
+
+char SFE_BMP180::initCalibration()
+// Load calibration data from the device
+{
+	double c3,c4,b1;
 
 	// The BMP180 includes factory calibration data stored on the device.
 	// Each device has different numbers, these must be retrieved and

--- a/src/SFE_BMP180.h
+++ b/src/SFE_BMP180.h
@@ -32,8 +32,10 @@ class SFE_BMP180
 		SFE_BMP180(); // base type
 
 		char begin();
+		char begin(int sda, int slc);
 			// call pressure.begin() to initialize BMP180 before use
 			// returns 1 if success, 0 if failure (bad component or I2C bus shorted?)
+			// The pin used for I2C can be configured with sda and scl
 		
 		char startTemperature(void);
 			// command BMP180 to start a temperature measurement
@@ -77,6 +79,8 @@ class SFE_BMP180
 			// 4 = Other error
 
 	private:
+		char initCalibration();
+		// Load calibration data from the device
 	
 		char readInt(char address, int16_t &value);
 			// read an signed int (16 bits) from a BMP180 register


### PR DESCRIPTION
I have an ESP8266, model 201.
For I2C, I use pins 2 and 14 , but other model (such as esp01) use 0 and 2.
So give the possibility to configure sda and slc pins and also keep the previous default behavior.
