### PR TITLE
Fix compile warnings + correct variable types

### DIFF
--- a/src/SFE_BMP180.cpp
+++ b/src/SFE_BMP180.cpp
@@ -23,6 +23,20 @@
 #include <math.h>
 
 
+namespace {
+	const uint8_t BMP180_ADDR = 0x77; // 7-bit address
+
+	const uint8_t BMP180_REG_CONTROL = 0xF4;
+	const uint8_t BMP180_REG_RESULT = 0xF6;
+
+	const uint8_t BMP180_COMMAND_TEMPERATURE = 0x2E;
+	const uint8_t BMP180_COMMAND_PRESSURE0 = 0x34;
+	const uint8_t BMP180_COMMAND_PRESSURE1 = 0x74;
+	const uint8_t BMP180_COMMAND_PRESSURE2 = 0xB4;
+	const uint8_t BMP180_COMMAND_PRESSURE3 = 0xF4;
+}
+
+
 SFE_BMP180::SFE_BMP180()
 // Base library type
 {
@@ -135,12 +149,12 @@ char SFE_BMP180::begin()
 }
 
 
-char SFE_BMP180::readInt(char address, int16_t &value)
+char SFE_BMP180::readInt(uint8_t address, int16_t &value)
 // Read a signed integer (two bytes) from device
 // address: register to start reading (plus subsequent register)
 // value: external variable to store data (function modifies value)
 {
-	unsigned char data[2];
+	uint8_t data[2];
 
 	data[0] = address;
 	if (readBytes(data,2))
@@ -154,12 +168,12 @@ char SFE_BMP180::readInt(char address, int16_t &value)
 }
 
 
-char SFE_BMP180::readUInt(char address, uint16_t &value)
+char SFE_BMP180::readUInt(uint8_t address, uint16_t &value)
 // Read an unsigned integer (two bytes) from device
 // address: register to start reading (plus subsequent register)
 // value: external variable to store data (function modifies value)
 {
-	unsigned char data[2];
+	uint8_t data[2];
 
 	data[0] = address;
 	if (readBytes(data,2))
@@ -172,13 +186,11 @@ char SFE_BMP180::readUInt(char address, uint16_t &value)
 }
 
 
-char SFE_BMP180::readBytes(unsigned char *values, char length)
+char SFE_BMP180::readBytes(uint8_t *values, uint8_t length)
 // Read an array of bytes from device
 // values: external array to hold data. Put starting register in values[0].
 // length: number of bytes to read
 {
-	char x;
-
 	Wire.beginTransmission(BMP180_ADDR);
 	Wire.write(values[0]);
 	_error = Wire.endTransmission();
@@ -186,7 +198,7 @@ char SFE_BMP180::readBytes(unsigned char *values, char length)
 	{
 		Wire.requestFrom(BMP180_ADDR,length);
 		while(Wire.available() != length) ; // wait until bytes are ready
-		for(x=0;x<length;x++)
+		for(uint8_t x = 0; x < length; x++)
 		{
 			values[x] = Wire.read();
 		}
@@ -196,13 +208,11 @@ char SFE_BMP180::readBytes(unsigned char *values, char length)
 }
 
 
-char SFE_BMP180::writeBytes(unsigned char *values, char length)
+char SFE_BMP180::writeBytes(uint8_t *values, uint8_t length)
 // Write an array of bytes to device
 // values: external array of data to write. Put starting register in values[0].
 // length: number of bytes to write
 {
-	char x;
-	
 	Wire.beginTransmission(BMP180_ADDR);
 	Wire.write(values,length);
 	_error = Wire.endTransmission();
@@ -217,7 +227,7 @@ char SFE_BMP180::startTemperature(void)
 // Begin a temperature reading.
 // Will return delay in ms to wait, or 0 if I2C error
 {
-	unsigned char data[2], result;
+	uint8_t data[2], result;
 	
 	data[0] = BMP180_REG_CONTROL;
 	data[1] = BMP180_COMMAND_TEMPERATURE;
@@ -236,7 +246,7 @@ char SFE_BMP180::getTemperature(double &T)
 // T: external variable to hold result.
 // Returns 1 if successful, 0 if I2C error.
 {
-	unsigned char data[2];
+	uint8_t data[2];
 	char result;
 	double tu, a;
 	
@@ -272,7 +282,7 @@ char SFE_BMP180::startPressure(char oversampling)
 // Oversampling: 0 to 3, higher numbers are slower, higher-res outputs.
 // Will return delay in ms to wait, or 0 if I2C error.
 {
-	unsigned char data[2], result, delay;
+	uint8_t data[2], result, delay;
 	
 	data[0] = BMP180_REG_CONTROL;
 
@@ -319,7 +329,7 @@ char SFE_BMP180::getPressure(double &P, double &T)
 
 // Note that calculated pressure value is absolute mbars, to compensate for altitude call sealevel().
 {
-	unsigned char data[3];
+	uint8_t data[3];
 	char result;
 	double pu,s,x,y,z;
 	

--- a/src/SFE_BMP180.h
+++ b/src/SFE_BMP180.h
@@ -78,25 +78,25 @@ class SFE_BMP180
 
 	private:
 	
-		char readInt(char address, int16_t &value);
+		char readInt(uint8_t address, int16_t &value);
 			// read an signed int (16 bits) from a BMP180 register
 			// address: BMP180 register address
 			// value: external signed int for returned value (16 bits)
 			// returns 1 for success, 0 for fail, with result in value
 
-		char readUInt(char address, uint16_t &value);
+		char readUInt(uint8_t address, uint16_t &value);
 			// read an unsigned int (16 bits) from a BMP180 register
 			// address: BMP180 register address
 			// value: external unsigned int for returned value (16 bits)
 			// returns 1 for success, 0 for fail, with result in value
 
-		char readBytes(unsigned char *values, char length);
+		char readBytes(uint8_t *values, uint8_t length);
 			// read a number of bytes from a BMP180 register
 			// values: array of char with register address in first location [0]
 			// length: number of bytes to read back
 			// returns 1 for success, 0 for fail, with read bytes in values[] array
 			
-		char writeBytes(unsigned char *values, char length);
+		char writeBytes(uint8_t *values, uint8_t length);
 			// write a number of bytes to a BMP180 register (and consecutive subsequent registers)
 			// values: array of char with register address in first location [0]
 			// length: number of bytes to write
@@ -107,16 +107,5 @@ class SFE_BMP180
 		double c5,c6,mc,md,x0,x1,x2,y0,y1,y2,p0,p1,p2;
 		char _error;
 };
-
-#define BMP180_ADDR 0x77 // 7-bit address
-
-#define	BMP180_REG_CONTROL 0xF4
-#define	BMP180_REG_RESULT 0xF6
-
-#define	BMP180_COMMAND_TEMPERATURE 0x2E
-#define	BMP180_COMMAND_PRESSURE0 0x34
-#define	BMP180_COMMAND_PRESSURE1 0x74
-#define	BMP180_COMMAND_PRESSURE2 0xB4
-#define	BMP180_COMMAND_PRESSURE3 0xF4
 
 #endif


### PR DESCRIPTION
Fixed compile warnings:

```
SFE_BMP180.cpp: In member function 'char SFE_BMP180::readBytes(unsigned char*, char)':
SFE_BMP180.cpp:191:12: warning: array subscript has type 'char' [-Wchar-subscripts]
values[x] = Wire.read();
^
SFE_BMP180.cpp: In member function 'char SFE_BMP180::writeBytes(unsigned char*, char)':
SFE_BMP180.cpp:204:7: warning: unused variable 'x' [-Wunused-variable]
char x;
^
```
